### PR TITLE
Implement field using s2n-bignum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/s2n-bignum/
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,98 @@
+OBJ = bignum_add_p25519.o \
+      bignum_sub_p25519.o \
+      bignum_mul_p25519.o \
+      bignum_sqr_p25519.o
+
+
+.PHONY: help
+help: ## Display this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+.PHONY: test
+test: ## Run tests
+	go test -v -count=1 ./...
+
+
+.PHONY: verify-field
+verify-field: verify-field-amd64 verify-field-arm64 ## Verify field operations: both amd64 and arm64 assembly output matches s2n-bignum
+
+
+.PHONY: verify-field-amd64
+verify-field-amd64: build-field ## Verify field operations: amd64 assembly output matches s2n-bignum
+	@for obj in $(OBJ); do \
+		func=$$(basename $$obj .o); \
+		echo "Verifying amd64 $$func..."; \
+		\
+		objdump --disassemble=github.com/AlexanderYastrebov/vanity25519/field.$$func.abi0 --no-show-raw-insn --no-addresses build/field.amd64.test | \
+			awk "/$$func.abi0>:/{flag=1; next} flag {print}" | \
+			grep -vF 'mov    0x8(%rsp),%rdi' | \
+			grep -vF 'mov    0x10(%rsp),%rsi' | \
+			grep -vF 'mov    0x18(%rsp),%rdx' | \
+			grep -vF 'mov    0x18(%rsp),%rcx' \
+		> build/$$func.amd64.go.asm ; \
+		\
+		objdump -d --no-show-raw-insn --no-addresses ./s2n-bignum/x86/curve25519/$$func.o | \
+			awk "/$$func>:/{flag=1; next} flag {print}" | \
+			grep -vF 'endbr64' | \
+			grep -vF 'mov    %rdx,%rcx' \
+		> build/$$func.amd64.s2n.asm ; \
+		\
+		diff -U3 build/$$func.amd64.go.asm build/$$func.amd64.s2n.asm || { echo "Verification failed for $$func"; exit 1; }; \
+	done
+
+
+.PHONY: verify-field-arm64
+verify-field-arm64: build-field ## Verify field operations: arm64 assembly output matches s2n-bignum
+	@for obj in $(OBJ); do \
+		func=$$(basename $$obj .o); \
+		echo "Verifying arm64 $$func..."; \
+		\
+		aarch64-linux-gnu-objdump --disassemble=github.com/AlexanderYastrebov/vanity25519/field.$$func.abi0 --no-show-raw-insn --no-addresses build/field.arm64.test | \
+			awk "/$$func.abi0>:/{flag=1; next} flag {print}" | \
+			grep -vF 'ldr	x0, [sp, #8]' | \
+			grep -vF 'ldr	x1, [sp, #16]' | \
+			grep -vF 'ldr	x2, [sp, #24]' | \
+			grep -vF 'udf	#0' | \
+			grep -vF '...' \
+		> build/$$func.arm64.go.asm ; \
+		\
+		aarch64-linux-gnu-objdump -d --no-show-raw-insn --no-addresses ./s2n-bignum/arm/curve25519/$$func.o | \
+			awk "/$$func>:/{flag=1; next} flag {print}" \
+		> build/$$func.arm64.s2n.asm ; \
+		\
+		diff -U3 build/$$func.arm64.go.asm build/$$func.arm64.s2n.asm || { echo "Verification failed for $$func"; exit 1; }; \
+	done
+
+
+.PHONY: test-field
+test-field: build-field ## Run field tests for both amd64 and arm64. Requires qemu-user-static and binfmt-support installed on amd64 host.
+	GOARCH=amd64 go test -count=1 ./field
+	GOARCH=arm64 go test -count=1 ./field
+
+
+.PHONY: build-field
+build-field: s2n-bignum ## Build field test binaries and s2n-bignum objects
+	mkdir -p build
+	GOARCH=amd64 go test -c -o build/field.amd64.test ./field
+	GOARCH=arm64 go test -c -o build/field.arm64.test ./field
+
+
+.PHONY: s2n-bignum
+s2n-bignum: ## Clone and build s2n-bignum if not already present
+	if [ ! -d ./s2n-bignum/ ]; then \
+		git clone --depth=1 git@github.com:awslabs/s2n-bignum.git; \
+	fi
+	make -C s2n-bignum/x86/curve25519/
+	make -C s2n-bignum/arm/curve25519/
+
+
+.PHONY: fmt
+fmt: ## Format Go and assembly code
+	gofumpt -w .
+	asmfmt -w .
+
+
+.PHONY: clean
+clean: ## Clean build artifacts
+	rm -rf build/ s2n-bignum/

--- a/field/bignum_add_p25519_amd64.s
+++ b/field/bignum_add_p25519_amd64.s
@@ -1,0 +1,65 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/x86/curve25519/bignum_add_p25519.S
+
+//go:build amd64 && gc && !purego
+
+#include "textflag.h"
+
+#define z DI
+#define x SI
+#define y DX
+
+#define d0 R8
+#define d1 R9
+#define d2 R10
+#define d3 R11
+
+#define c0 AX
+#define c1 CX
+#define c2 SI
+#define c3 DX
+
+// func bignum_add_p25519(out *Element, a *Element, b *Element)
+TEXT ·bignum_add_p25519(SB), NOSPLIT, $0-24
+	MOVQ out+0(FP), z
+	MOVQ a+8(FP), x
+	MOVQ b+16(FP), y
+
+	// Add as [d3; d2; d1; d0] = x + y; since we assume x, y < 2^255 - 19
+	// this sum fits in 256 bits.
+	MOVQ (x), d0
+	ADDQ (y), d0
+	MOVQ 8(x), d1
+	ADCQ 8(y), d1
+	MOVQ 16(x), d2
+	ADCQ 16(y), d2
+	MOVQ 24(x), d3
+	ADCQ 24(y), d3
+
+	// Now x + y >= 2^255 - 19 <=> x + y + 19 >= 2^255.
+	// Form [c3; c2; c1; c0] = (x + y) + 19
+	MOVL $19, c0
+	XORL c1, c1
+	XORL c2, c2
+	XORL c3, c3
+
+	ADDQ d0, c0
+	ADCQ d1, c1
+	ADCQ d2, c2
+	ADCQ d3, c3
+
+	// Test the top bit to see if this is >= 2^255, and clear it as a masking
+	// so that in that case the result is exactly (x + y) - (2^255 - 19).
+	// Then select the output according to that top bit as that or just x + y.
+	BTRQ    $63, c3
+	CMOVQCS c0, d0
+	CMOVQCS c1, d1
+	CMOVQCS c2, d2
+	CMOVQCS c3, d3
+
+	// Store the result
+	MOVQ d0, (z)
+	MOVQ d1, 8(z)
+	MOVQ d2, 16(z)
+	MOVQ d3, 24(z)
+	RET

--- a/field/bignum_add_p25519_arm64.s
+++ b/field/bignum_add_p25519_arm64.s
@@ -1,0 +1,56 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/arm/curve25519/bignum_add_p25519.S
+
+//go:build arm64 && gc && !purego
+
+#include "textflag.h"
+
+#define z R0
+#define x R1
+#define y R2
+#define d0 R3
+#define d1 R4
+#define d2 R5
+#define d3 R6
+#define c0 R7
+#define c1 R8
+#define c2 R9
+#define c3 R10
+
+// func bignum_add_p25519(out *Element, a *Element, b *Element)
+TEXT ·bignum_add_p25519(SB), NOSPLIT, $0-24
+	MOVD out+0(FP), z
+	MOVD a+8(FP), x
+	MOVD b+16(FP), y
+
+	// Add as [d3; d2; d1; d0] = x + y; since we assume x, y < 2^255 - 19
+	// this sum fits in 256 bits
+	LDP  (x), (d0, d1)
+	LDP  (y), (c0, c1)
+	ADDS c0, d0, d0
+	ADCS c1, d1, d1
+	LDP  16(x), (d2, d3)
+	LDP  16(y), (c0, c1)
+	ADCS c0, d2, d2
+	ADC  c1, d3, d3
+
+	// Now x + y >= 2^255 - 19 <=> x + y + (2^255 + 19) >= 2^256
+	// Form [c3; c2; c1; c0] = (x + y) + (2^255 + 19), with CF for the comparison
+	MOVD $0x8000000000000000, c3
+	ADDS $19, d0, c0
+	ADCS ZR, d1, c1
+	ADCS ZR, d2, c2
+	ADCS c3, d3, c3
+
+	// If the comparison holds, select [c3; c2; c1; c0]. There's no need to mask
+	// it since in this case it is ((x + y) + (2^255 + 19)) - 2^256 because the
+	// top carry is lost, which is the desired (x + y) - (2^255 - 19).
+	CSEL CC, d0, c0, d0
+	CSEL CC, d1, c1, d1
+	CSEL CC, d2, c2, d2
+	CSEL CC, d3, c3, d3
+
+	// Store the result
+	STP (d0, d1), (z)
+	STP (d2, d3), 16(z)
+	RET

--- a/field/bignum_mul_p25519_amd64.s
+++ b/field/bignum_mul_p25519_amd64.s
@@ -1,0 +1,154 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/x86/curve25519/bignum_mul_p25519.S
+
+//go:build amd64 && gc && !purego
+
+#include "textflag.h"
+
+#define z DI
+#define x SI
+#define y CX
+
+// A zero register
+#define zero BP
+#define zeroe BP
+
+// mulpadd(high,low,m) adds rdx * m to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using rax and rbx as temporaries.
+#define mulpadd(high, low, m) \
+	MULXQ m, AX, BX; \
+	ADCXQ AX, low;   \
+	ADOXQ BX, high
+
+// mulpade(high,low,m) adds rdx * m to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using rax as a temporary, assuming high created from scratch
+// and that zero has value zero.
+#define mulpade(high, low, m) \
+	MULXQ m, AX, high; \
+	ADCXQ AX, low;     \
+	ADOXQ zero, high
+
+// func bignum_mul_p25519(out *Element, a *Element, b *Element)
+TEXT ·bignum_mul_p25519(SB), NOSPLIT, $0-24
+	MOVQ out+0(FP), z
+	MOVQ a+8(FP), x
+	MOVQ b+16(FP), y
+
+	// Save more registers to play with
+	PUSHQ BX
+	PUSHQ BP
+	PUSHQ R12
+	PUSHQ R13
+	PUSHQ R14
+	PUSHQ R15
+
+	// Zero a register, which also makes sure we don't get a fake carry-in
+	XORL zeroe, zeroe
+
+	// Do the zeroth row, which is a bit different
+	MOVQ (y), DX
+
+	MULXQ (x), R8, R9
+	MULXQ 8(x), AX, R10
+	ADDQ  AX, R9
+	MULXQ 16(x), AX, R11
+	ADCQ  AX, R10
+	MULXQ 24(x), AX, R12
+	ADCQ  AX, R11
+	ADCQ  zero, R12
+
+	// Add row 1
+	XORL zeroe, zeroe
+	MOVQ 8(y), DX
+
+	mulpadd(R10,R9,(x))
+	mulpadd(R11,R10,8(x))
+	mulpadd(R12,R11,16(x))
+	mulpade(R13,R12,24(x))
+	ADCQ zero, R13
+
+	// Add row 2
+	XORL zeroe, zeroe
+	MOVQ 16(y), DX
+
+	mulpadd(R11,R10,(x))
+	mulpadd(R12,R11,8(x))
+	mulpadd(R13,R12,16(x))
+	mulpade(R14,R13,24(x))
+	ADCQ zero, R14
+
+	// Add row 3; also use an early 38*r15+r11 to get a quotient estimate q
+	// and then squeeze in a 19 * q computation to inject into the next
+	// double-carry chain. At the end rcx = q and rax = 19 * q.
+	XORL zeroe, zeroe
+	MOVQ 24(y), DX
+
+	mulpadd(R12,R11,(x))
+
+	MULXQ 24(x), CX, R15
+
+	mulpadd(R13,R12,8(x))
+	mulpadd(R14,R13,16(x))
+
+	MOVL  $38, DX
+	MULXQ R15, AX, BX
+
+	ADCXQ CX, R14
+	ADOXQ zero, R15
+	ADCQ  zero, R15
+
+	ADDQ  R11, AX
+	ADCQ  zero, BX
+	BTQ   $63, AX
+	ADCQ  BX, BX
+	LEAQ  1(BX), CX
+	IMULQ $19, CX
+
+	// Now we have the full 8-digit product 2^256 * h + l where
+	// h = [r15,r14,r13,r12] and l = [r11,r10,r9,r8]
+	// and this is == 38 * h + l (mod p_25519)
+	// We add in the precalculated 19 * q as well.
+	// This is kept in 4 words since we have enough information there.
+	XORL  zeroe, zeroe
+	ADOXQ CX, R8
+
+	mulpadd(R9,R8,R12)
+	mulpadd(R10,R9,R13)
+	mulpadd(R11,R10,R14)
+	MULXQ R15, AX, BX
+	ADCQ  AX, R11
+
+	// We still haven't made the -2^255 * q contribution yet. Since we
+	// are now safely in 4 words we just need a single bit of q, and we
+	// can actually use the LSB of rcx = 19 * q since 19 is odd. And we
+	// don't literally need to subtract, just to see whether we would
+	// have a top 1 bit if we did, meaning we need to correct in the
+	// last step by adding 2^255 - 19.
+	SHLQ    $63, CX
+	CMPQ    R11, CX
+	MOVL    $19, AX
+	CMOVQPL zero, AX
+
+	// Now make that possible correction and finally mask to 255 bits
+	SUBQ AX, R8
+	SBBQ zero, R9
+	SBBQ zero, R10
+	SBBQ zero, R11
+	BTRQ $63, R11
+
+	// Write everything back
+	MOVQ R8, (z)
+	MOVQ R9, 8(z)
+	MOVQ R10, 16(z)
+	MOVQ R11, 24(z)
+
+	// Restore registers and return
+	POPQ R15
+	POPQ R14
+	POPQ R13
+	POPQ R12
+	POPQ BP
+	POPQ BX
+	RET

--- a/field/bignum_mul_p25519_arm64.s
+++ b/field/bignum_mul_p25519_arm64.s
@@ -1,0 +1,310 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/arm/curve25519/bignum_mul_p25519.S
+
+//go:build arm64 && gc && !purego
+
+#include "textflag.h"
+
+#define z R0
+#define x R1
+#define y R2
+
+#define a0 R3
+#define a0short R3
+#define a1 R4
+#define b0 R5
+#define b0short R5
+#define b1 R6
+
+#define u0 R7
+#define u1 R8
+#define u2 R9
+#define u3 R10
+#define u4 R11
+#define u5 R12
+#define u6 R13
+#define u7 R14
+
+#define u0short R7
+#define u1short R8
+#define u2short R9
+#define u3short R10
+#define u4short R11
+#define u5short R12
+#define u6short R13
+#define u7short R14
+
+#define t R15
+
+#define sgn R16
+#define ysgn R17
+
+// These are aliases to registers used elsewhere including input pointers.
+// By the time they are used this does not conflict with other uses.
+
+#define m0 y
+#define m1 ysgn
+#define m2 t
+#define m3 x
+#define u u2
+
+// For the reduction stages, again aliasing other things but not the u's
+
+#define c R3
+#define cshort R3
+#define h R4
+#define l R5
+#define lshort R5
+#define d R6
+#define q R17
+#define qshort R17
+
+// func bignum_mul_p25519(out *Element, a *Element, b *Element)
+TEXT ·bignum_mul_p25519(SB), NOSPLIT, $0-24
+	MOVD out+0(FP), z
+	MOVD a+8(FP), x
+	MOVD b+16(FP), y
+
+	// Multiply the low halves using Karatsuba 2x2->4 to get [u3,u2,u1,u0]
+	LDP (x), (a0, a1)
+	LDP (y), (b0, b1)
+
+	UMULL b0short, a0short, u0
+	LSR   $32, a0, R17
+	UMULL b0short, R17, R15
+	LSR   $32, b0, R16
+	UMULL R17, R16, u1
+	UMULL R16, a0short, R16
+	ADDS  R15<<32, u0, u0
+	LSR   $32, R15, R15
+	ADC   R15, u1, u1
+	ADDS  R16<<32, u0, u0
+	LSR   $32, R16, R16
+	ADC   R16, u1, u1
+
+	MUL   b1, a1, u2
+	UMULH b1, a1, u3
+
+	SUBS  a0, a1, a1
+	CNEG  CC, a1, a1
+	CSETM CC, sgn
+
+	ADDS u1, u2, u2
+	ADC  ZR, u3, u3
+
+	SUBS b1, b0, a0
+	CNEG CC, a0, a0
+	CINV CC, sgn, sgn
+
+	MUL   a0, a1, t
+	UMULH a0, a1, a0
+
+	ADDS u2, u0, u1
+	ADCS u3, u2, u2
+	ADC  ZR, u3, u3
+
+	CMN  $1, sgn
+	EOR  sgn, t, t
+	ADCS u1, t, u1
+	EOR  sgn, a0, a0
+	ADCS u2, a0, u2
+	ADC  sgn, u3, u3
+
+	// Multiply the high halves using Karatsuba 2x2->4 to get [u7,u6,u5,u4]
+	LDP 16(x), (a0, a1)
+	LDP 16(y), (b0, b1)
+
+	UMULL b0short, a0short, u4
+	LSR   $32, a0, R17
+	UMULL b0short, R17, R15
+	LSR   $32, b0, R16
+	UMULL R17, R16, u5
+	UMULL R16, a0short, R16
+	ADDS  R15<<32, u4, u4
+	LSR   $32, R15, R15
+	ADC   R15, u5, u5
+	ADDS  R16<<32, u4, u4
+	LSR   $32, R16, R16
+	ADC   R16, u5, u5
+
+	MUL   b1, a1, u6
+	UMULH b1, a1, u7
+
+	SUBS  a0, a1, a1
+	CNEG  CC, a1, a1
+	CSETM CC, sgn
+
+	ADDS u5, u6, u6
+	ADC  ZR, u7, u7
+
+	SUBS b1, b0, a0
+	CNEG CC, a0, a0
+	CINV CC, sgn, sgn
+
+	MUL   a0, a1, t
+	UMULH a0, a1, a0
+
+	ADDS u6, u4, u5
+	ADCS u7, u6, u6
+	ADC  ZR, u7, u7
+
+	CMN  $1, sgn
+	EOR  sgn, t, t
+	ADCS u5, t, u5
+	EOR  sgn, a0, a0
+	ADCS u6, a0, u6
+	ADC  sgn, u7, u7
+
+	// Compute  sgn,[a1,a0] = x_hi - x_lo
+	// and     ysgn,[b1,b0] = y_lo - y_hi
+	// sign-magnitude differences
+	LDP   16(x), (a0, a1)
+	LDP   (x), (t, sgn)
+	SUBS  t, a0, a0
+	SBCS  sgn, a1, a1
+	CSETM CC, sgn
+
+	LDP   (y), (t, ysgn)
+	SUBS  b0, t, b0
+	SBCS  b1, ysgn, b1
+	CSETM CC, ysgn
+
+	EOR  sgn, a0, a0
+	SUBS sgn, a0, a0
+	EOR  sgn, a1, a1
+	SBC  sgn, a1, a1
+
+	EOR  ysgn, b0, b0
+	SUBS ysgn, b0, b0
+	EOR  ysgn, b1, b1
+	SBC  ysgn, b1, b1
+
+	// Save the correct sign for the sub-product
+	EOR sgn, ysgn, sgn
+
+	// Add H' = H + L_top, still in [u7,u6,u5,u4]
+	ADDS u2, u4, u4
+	ADCS u3, u5, u5
+	ADCS ZR, u6, u6
+	ADC  ZR, u7, u7
+
+	// Now compute the mid-product as [m3,m2,m1,m0]
+	MUL   b0, a0, m0
+	UMULH b0, a0, m1
+	MUL   b1, a1, m2
+	UMULH b1, a1, m3
+
+	SUBS  a0, a1, a1
+	CNEG  CC, a1, a1
+	CSETM CC, u
+
+	ADDS m1, m2, m2
+	ADC  ZR, m3, m3
+
+	SUBS b1, b0, b1
+	CNEG CC, b1, b1
+	CINV CC, u, u
+
+	MUL   b1, a1, b0
+	UMULH b1, a1, b1
+
+	ADDS m2, m0, m1
+	ADCS m3, m2, m2
+	ADC  ZR, m3, m3
+
+	CMN  $1, u
+	EOR  u, b0, b0
+	ADCS m1, b0, m1
+	EOR  u, b1, b1
+	ADCS m2, b1, m2
+	ADC  u, m3, m3
+
+	// Accumulate the positive mid-terms as [u7,u6,u5,u4,u3,u2]
+	ADDS u0, u4, u2
+	ADCS u1, u5, u3
+	ADCS u4, u6, u4
+	ADCS u5, u7, u5
+	ADCS ZR, u6, u6
+	ADC  ZR, u7, u7
+
+	// Add in the sign-adjusted complex term
+	CMN  $1, sgn
+	EOR  sgn, m0, m0
+	ADCS u2, m0, u2
+	EOR  sgn, m1, m1
+	ADCS u3, m1, u3
+	EOR  sgn, m2, m2
+	ADCS u4, m2, u4
+	EOR  sgn, m3, m3
+	ADCS u5, m3, u5
+	ADCS sgn, u6, u6
+	ADC  sgn, u7, u7
+
+	// Now we have the full 8-digit product 2^256 * h + l where
+	// h = [u7,u6,u5,u4] and l = [u3,u2,u1,u0]
+	// and this is == 38 * h + l (mod p_25519).
+	// We do the 38 * h + l using 32-bit multiplies avoiding umulh,
+	// and pre-estimate and feed in the next-level quotient
+	// q = h + 1 where h = an early version of the high 255 bits.
+	// We add 2^255 * h - 19 * (h + 1), so end up offset by 2^255.
+	MOVD $38, c
+
+	UMULL  cshort, u4short, h
+	ADD    u0short.UXTW, h, h
+	LSR    $32, u0, u0
+	LSR    $32, u4, u4
+	UMADDL cshort, u0, u4, u4short
+	MOVD   h, u0
+
+	UMULL  cshort, u5short, h
+	ADD    u1short.UXTW, h, h
+	LSR    $32, u1, u1
+	LSR    $32, u5, u5
+	UMADDL cshort, u1, u5, u5short
+	MOVD   h, u1
+
+	UMULL  cshort, u6short, h
+	ADD    u2short.UXTW, h, h
+	LSR    $32, u2, u2
+	LSR    $32, u6, u6
+	UMADDL cshort, u2, u6, u6short
+	MOVD   h, u2
+
+	UMULL  cshort, u7short, h
+	ADD    u3short.UXTW, h, h
+	LSR    $32, u3, u3
+	LSR    $32, u7, u7
+	UMADDL cshort, u3, u7, u7short
+	MOVD   h, u3
+
+	LSR $31, u7, q
+
+	MOVD   $19, l
+	UMADDL qshort, lshort, l, l
+	ADD    l, u0, u0
+
+	ADDS u4<<32, u0, u0
+	EXTR $32, u4, u5, c
+	ADCS c, u1, u1
+	EXTR $32, u5, u6, c
+	ADCS c, u2, u2
+	EXTR $32, u6, u7, c
+	LSL  $63, q, l
+	EOR  l, u3, u3
+	ADC  c, u3, u3
+
+	// Now we correct by a final 2^255-19 if the top bit is clear
+	// meaning that the "real" pre-reduced result is negative.
+	MOVD $19, c
+	TST  $0x8000000000000000, u3
+	CSEL PL, c, ZR, c
+	SUBS c, u0, u0
+	SBCS ZR, u1, u1
+	SBCS ZR, u2, u2
+	SBC  ZR, u3, u3
+	AND  $~0x8000000000000000, u3, u3
+
+	// Write back result
+	STP (u0, u1), (z)
+	STP (u2, u3), 16(z)
+	RET

--- a/field/bignum_sqr_p25519_amd64.s
+++ b/field/bignum_sqr_p25519_amd64.s
@@ -1,0 +1,146 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/x86/curve25519/bignum_sqr_p25519.S
+
+//go:build amd64 && gc && !purego
+
+#include "textflag.h"
+
+#define z DI
+#define x SI
+
+// Use this fairly consistently for a zero
+#define zero BX
+#define zeroe BX
+
+// Add rdx * m into a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using rax and rcx as temporaries
+#define mulpadd(high, low, m) \
+	MULXQ m, AX, CX; \
+	ADCXQ AX, low;   \
+	ADOXQ CX, high
+
+// mulpade(high,low,m) adds rdx * m to a register-pair (high,low)
+// maintaining consistent double-carrying with adcx and adox,
+// using rax as a temporary, assuming high created from scratch
+// and that zero has value zero.
+#define mulpade(high, low, m) \
+	MULXQ m, high, AX; \
+	ADCXQ AX, low;     \
+	ADOXQ zero, high
+
+// func bignum_sqr_p25519(out *Element, a *Element)
+TEXT ·bignum_sqr_p25519(SB), NOSPLIT, $0-16
+	MOVQ out+0(FP), z
+	MOVQ a+8(FP), x
+
+	// Save more registers to play with
+	PUSHQ BX
+	PUSHQ R12
+	PUSHQ R13
+	PUSHQ R14
+	PUSHQ R15
+
+	// Compute [r15;r8] = [00] which we use later, but mainly
+	// set up an initial window [r14;...;r9] = [23;03;01]
+	MOVQ  (x), DX
+	MULXQ DX, R8, R15
+	MULXQ 8(x), R9, R10
+	MULXQ 24(x), R11, R12
+	MOVQ  16(x), DX
+	MULXQ 24(x), R13, R14
+
+	// Clear our zero register, and also initialize the flags for the carry chain
+	XORL zeroe, zeroe
+
+	// Chain in the addition of 02 + 12 + 13 to that window (no carry-out possible)
+	// This gives all the "heterogeneous" terms of the squaring ready to double
+	mulpadd(R11,R10,(x))
+	mulpadd(R12,R11,8(x))
+	MOVQ  24(x), DX
+	mulpadd(R13,R12,8(x))
+	ADCXQ zero, R13
+	ADOXQ zero, R14
+	ADCQ  zero, R14
+
+	// Double and add to the 00 + 11 + 22 + 33 terms, while also
+	// pre-estimating the quotient from early results.
+	XORL  zeroe, zeroe
+	ADCXQ R9, R9
+	ADOXQ R15, R9
+	MOVQ  8(x), DX
+	MULXQ DX, AX, CX
+	ADCXQ R10, R10
+	ADOXQ AX, R10
+	ADCXQ R11, R11
+	ADOXQ CX, R11
+	MOVQ  16(x), DX
+	MULXQ DX, AX, CX
+	ADCXQ R12, R12
+	ADOXQ AX, R12
+	ADCXQ R13, R13
+	ADOXQ CX, R13
+	MOVQ  24(x), DX
+	MULXQ DX, AX, R15
+
+	MOVL  $38, DX
+	MULXQ R15, DX, CX
+
+	ADCXQ R14, R14
+	ADOXQ AX, R14
+	ADCXQ zero, R15
+	ADOXQ zero, R15
+
+	ADDQ  R11, DX
+	ADCQ  zero, CX
+	SHLQ  $1, DX, CX
+	LEAQ  1(CX), BX
+	IMULQ $19, BX
+
+	// Now we have the full 8-digit product 2^256 * h + l where
+	// h = [r15,r14,r13,r12] and l = [r11,r10,r9,r8]
+	// and this is == 38 * h + l (mod p_25519)
+	// We add in the precalculated 19 * q as well.
+	// This is kept in 4 words since we have enough information there.
+	XORL  AX, AX
+	ADOXQ BX, R8
+	MOVL  $38, DX
+	mulpadd(R9,R8,R12)
+	mulpadd(R10,R9,R13)
+	mulpadd(R11,R10,R14)
+	MULXQ R15, AX, CX
+	ADCQ  AX, R11
+
+	// We still haven't made the -2^255 * q contribution yet. Since we
+	// are now safely in 4 words we just need a single bit of q, and we
+	// can actually use the LSB of rcx = 19 * q since 19 is odd. And we
+	// don't literally need to subtract, just to see whether we would
+	// have a top 1 bit if we did, meaning we need to correct in the
+	// last step by adding 2^255 - 19.
+	XORL    CX, CX
+	SHLQ    $63, BX
+	CMPQ    R11, BX
+	MOVL    $19, AX
+	CMOVQPL CX, AX
+
+	// Now make that possible correction and finally mask to 255 bits
+	SUBQ AX, R8
+	SBBQ CX, R9
+	SBBQ CX, R10
+	SBBQ CX, R11
+	BTRQ $63, R11
+
+	// Write everything back
+	MOVQ R8, (z)
+	MOVQ R9, 8(z)
+	MOVQ R10, 16(z)
+	MOVQ R11, 24(z)
+
+	// Restore registers and return
+	POPQ R15
+	POPQ R14
+	POPQ R13
+	POPQ R12
+	POPQ BX
+
+	RET

--- a/field/bignum_sqr_p25519_arm64.s
+++ b/field/bignum_sqr_p25519_arm64.s
@@ -1,0 +1,211 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/arm/curve25519/bignum_sqr_p25519.S
+
+//go:build arm64 && gc && !purego
+
+#include "textflag.h"
+
+#define z R0
+#define x R1
+
+// Variables
+#define u0 R2
+#define u1 R3
+#define u2 R4
+#define u3 R5
+#define u4 R6
+#define u5 R7
+#define u6 R8
+#define u7 R9
+
+#define u0short R2
+#define u1short R3
+#define u2short R4
+#define u3short R5
+#define u4short R6
+#define u5short R7
+#define u6short R8
+#define u7short R9
+
+#define c R10
+#define cshort R10
+#define l R11
+#define lshort R11
+#define h R12
+#define hshort R12
+#define q R13
+#define qshort R13
+
+#define t1 R14
+#define t1short R14
+#define t2 R15
+#define t2short R15
+#define t3 R16
+#define t3short R16
+
+// func bignum_sqr_p25519(out *Element, a *Element)
+TEXT ·bignum_sqr_p25519(SB), NOSPLIT, $0-16
+	MOVD out+0(FP), z
+	MOVD a+8(FP), x
+
+	// First just a near-clone of bignum_sqr_4_8 to get the square, using
+	// different registers to collect full product without writeback.
+	LDP   (x), (c, l)
+	LDP   16(x), (h, q)
+	UMULL cshort, cshort, u0
+	LSR   $32, c, t1
+	UMULL t1short, t1short, u1
+	UMULL t1short, cshort, t1
+	ADDS  t1<<33, u0, u0
+	LSR   $31, t1, t1
+	ADC   t1, u1, u1
+	UMULL lshort, lshort, u2
+	LSR   $32, l, t1
+	UMULL t1short, t1short, u3
+	UMULL t1short, lshort, t1
+	MUL   l, c, t2
+	UMULH l, c, t3
+	ADDS  t1<<33, u2, u2
+	LSR   $31, t1, t1
+	ADC   t1, u3, u3
+	ADDS  t2, t2, t2
+	ADCS  t3, t3, t3
+	ADC   ZR, u3, u3
+	ADDS  t2, u1, u1
+	ADCS  t3, u2, u2
+	ADC   ZR, u3, u3
+	UMULL hshort, hshort, u4
+	LSR   $32, h, t1
+	UMULL t1short, t1short, u5
+	UMULL t1short, hshort, t1
+	ADDS  t1<<33, u4, u4
+	LSR   $31, t1, t1
+	ADC   t1, u5, u5
+	UMULL qshort, qshort, u6
+	LSR   $32, q, t1
+	UMULL t1short, t1short, u7
+	UMULL t1short, qshort, t1
+	MUL   q, h, t2
+	UMULH q, h, t3
+	ADDS  t1<<33, u6, u6
+	LSR   $31, t1, t1
+	ADC   t1, u7, u7
+	ADDS  t2, t2, t2
+	ADCS  t3, t3, t3
+	ADC   ZR, u7, u7
+	ADDS  t2, u5, u5
+	ADCS  t3, u6, u6
+	ADC   ZR, u7, u7
+	SUBS  h, c, c
+	SBCS  q, l, l
+	CSETM CC, t3
+	EOR   t3, c, c
+	SUBS  t3, c, c
+	EOR   t3, l, l
+	SBC   t3, l, l
+	ADDS  u2, u4, u4
+	ADCS  u3, u5, u5
+	ADCS  ZR, u6, u6
+	ADC   ZR, u7, u7
+	UMULL cshort, cshort, h
+	LSR   $32, c, u3
+	UMULL u3short, u3short, q
+	UMULL u3short, cshort, u3
+	ADDS  u3<<33, h, h
+	LSR   $31, u3, u3
+	ADC   u3, q, q
+	UMULL lshort, lshort, t2
+	LSR   $32, l, u3
+	UMULL u3short, u3short, t1
+	UMULL u3short, lshort, u3
+	MUL   l, c, u2
+	UMULH l, c, t3
+	ADDS  u3<<33, t2, t2
+	LSR   $31, u3, u3
+	ADC   u3, t1, t1
+	ADDS  u2, u2, u2
+	ADCS  t3, t3, t3
+	ADC   ZR, t1, t1
+	ADDS  u2, q, q
+	ADCS  t3, t2, t2
+	ADC   ZR, t1, t1
+	ADDS  u4, u0, u2
+	ADCS  u5, u1, u3
+	ADCS  u6, u4, u4
+	ADCS  u7, u5, u5
+	CSETM CC, t3
+	SUBS  h, u2, u2
+	SBCS  q, u3, u3
+	SBCS  t2, u4, u4
+	SBCS  t1, u5, u5
+	ADCS  t3, u6, u6
+	ADC   t3, u7, u7
+
+	// Now we have the full 8-digit product 2^256 * h + l where
+	// h = [u7,u6,u5,u4] and l = [u3,u2,u1,u0]
+	// and this is == 38 * h + l (mod p_25519).
+	// We do the 38 * h + l using 32-bit multiplies avoiding umulh,
+	// and pre-estimate and feed in the next-level quotient
+	// q = h + 1 where h = an early version of the high 255 bits.
+	// We add 2^255 * h - 19 * (h + 1), so end up offset by 2^255.
+	MOVD $38, c
+
+	UMULL  cshort, u4short, h
+	ADD    u0short.UXTW, h, h
+	LSR    $32, u0, u0
+	LSR    $32, u4, u4
+	UMADDL cshort, u0, u4, u4short
+	MOVD   h, u0
+
+	UMULL  cshort, u5short, h
+	ADD    u1short.UXTW, h, h
+	LSR    $32, u1, u1
+	LSR    $32, u5, u5
+	UMADDL cshort, u1, u5, u5short
+	MOVD   h, u1
+
+	UMULL  cshort, u6short, h
+	ADD    u2short.UXTW, h, h
+	LSR    $32, u2, u2
+	LSR    $32, u6, u6
+	UMADDL cshort, u2, u6, u6short
+	MOVD   h, u2
+
+	UMULL  cshort, u7short, h
+	ADD    u3short.UXTW, h, h
+	LSR    $32, u3, u3
+	LSR    $32, u7, u7
+	UMADDL cshort, u3, u7, u7short
+	MOVD   h, u3
+
+	LSR $31, u7, q
+
+	MOVD   $19, l
+	UMADDL qshort, lshort, l, l
+	ADD    l, u0, u0
+
+	ADDS u4<<32, u0, u0
+	EXTR $32, u4, u5, c
+	ADCS c, u1, u1
+	EXTR $32, u5, u6, c
+	ADCS c, u2, u2
+	EXTR $32, u6, u7, c
+	LSL  $63, q, l
+	EOR  l, u3, u3
+	ADC  c, u3, u3
+
+	// Now we correct by a final 2^255-19 if the top bit is clear
+	// meaning that the "real" pre-reduced result is negative.
+	MOVD $19, c
+	TST  $0x8000000000000000, u3
+	CSEL PL, c, ZR, c
+	SUBS c, u0, u0
+	SBCS ZR, u1, u1
+	SBCS ZR, u2, u2
+	SBC  ZR, u3, u3
+	AND  $~0x8000000000000000, u3, u3
+
+	// Write back result
+	STP (u0, u1), (z)
+	STP (u2, u3), 16(z)
+	RET

--- a/field/bignum_sub_p25519_amd64.s
+++ b/field/bignum_sub_p25519_amd64.s
@@ -1,0 +1,53 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/x86/curve25519/bignum_sub_p25519.S
+
+//go:build amd64 && gc && !purego
+
+#include "textflag.h"
+
+#define z DI
+#define x SI
+#define y DX
+
+#define d0 R8
+#define d1 R9
+#define d2 R10
+#define d3 R11
+
+#define zero AX
+#define c CX
+
+// func bignum_sub_p25519(out *Element, a *Element, b *Element)
+TEXT ·bignum_sub_p25519(SB), NOSPLIT, $0-24
+	MOVQ out+0(FP), z
+	MOVQ a+8(FP), x
+	MOVQ b+16(FP), y
+
+	// Load and subtract the two inputs as [d3;d2;d1;d0] = x - y (modulo 2^256)
+	MOVQ (x), d0
+	SUBQ (y), d0
+	MOVQ 8(x), d1
+	SBBQ 8(y), d1
+	MOVQ 16(x), d2
+	SBBQ 16(y), d2
+	MOVQ 24(x), d3
+	SBBQ 24(y), d3
+
+	// Now if x < y we want to add back p_25519, which staying within 4 digits
+	// means subtracting 19, since p_25519 = 2^255 - 19.
+	// Let c be that constant 19 when x < y, zero otherwise.
+	SBBQ c, c
+	XORL zero, zero
+	ANDQ $19, c
+
+	// Correct by adding the optional constant and masking to 255 bits
+	SUBQ c, d0
+	MOVQ d0, (z)
+	SBBQ zero, d1
+	MOVQ d1, 8(z)
+	SBBQ zero, d2
+	MOVQ d2, 16(z)
+	SBBQ zero, d3
+	BTRQ $63, d3
+	MOVQ d3, 24(z)
+	RET

--- a/field/bignum_sub_p25519_arm64.s
+++ b/field/bignum_sub_p25519_arm64.s
@@ -1,0 +1,55 @@
+// Translated from the corresponding s2n-bignum function:
+// https://github.com/awslabs/s2n-bignum/blob/main/arm/curve25519/bignum_sub_p25519.S
+
+//go:build arm64 && gc && !purego
+
+#include "textflag.h"
+
+#define z R0
+#define x R1
+#define y R2
+#define c R3
+#define l R4
+#define d0 R5
+#define d1 R6
+#define d2 R7
+#define d3 R8
+
+// func bignum_sub_p25519(out *Element, a *Element, b *Element)
+TEXT ·bignum_sub_p25519(SB), NOSPLIT, $0-24
+	MOVD out+0(FP), z
+	MOVD a+8(FP), x
+	MOVD b+16(FP), y
+
+	// First just subtract the numbers as [d3; d2; d1; d0] = x - y,
+	// with the inverted carry flag meaning CF <=> x >= y.
+
+	LDP  (x), (d0, d1)
+	LDP  (y), (l, c)
+	SUBS l, d0, d0
+	SBCS c, d1, d1
+	LDP  16(x), (d2, d3)
+	LDP  16(y), (l, c)
+	SBCS l, d2, d2
+	SBCS c, d3, d3
+
+	// Now if x < y we want to add back p_25519, which staying within 255 bits
+	// means subtracting 19, since p_25519 = 2^255 - 19.
+	// Let c be that constant 19 when x < y, zero otherwise.
+
+	MOVD $19, l
+	CSEL LO, l, ZR, c
+
+	// Correct by adding the optional constant and masking to 255 bits
+
+	SUBS c, d0, d0
+	SBCS ZR, d1, d1
+	SBCS ZR, d2, d2
+	SBC  ZR, d3, d3
+	AND  $0x7FFFFFFFFFFFFFFF, d3, d3
+
+	// Store the result
+	STP (d0, d1), (z)
+	STP (d2, d3), 16(z)
+
+	RET

--- a/field/doc.go
+++ b/field/doc.go
@@ -1,0 +1,16 @@
+// Package field implements fast arithmetic modulo 2^255-19.
+//
+// [Element] type API is the same as [filippo.io/edwards25519/field.Element].
+//
+// Performance:
+// The package uses optimized assembly implementations translated from
+// Amazon's [s2n-bignum] library for
+// arithmetic operations on amd64 and arm64 architectures, providing
+// performance improvement over [filippo.io/edwards25519/field] implementation.
+//
+// The Go assembly files are translated from s2n-bignum's proven
+// assembly implementations and verified by comparing the disassembled machine code
+// output from the Go compiler against the original s2n-bignum implementations.
+//
+// [s2n-bignum]: https://github.com/awslabs/s2n-bignum
+package field

--- a/field/fe.go
+++ b/field/fe.go
@@ -1,0 +1,329 @@
+package field
+
+import (
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+)
+
+// Element represents an element of the field GF(2^255-19).
+//
+// This type works similarly to [filippo.io/edwards25519/field.Element],
+// and all arguments and receivers are allowed to alias.
+//
+// The zero value is a valid zero element.
+type Element struct {
+	// An element t represents the integer
+	//     t.l0 + t.l1*2^64 + t.l2*2^128 + t.l3*2^192
+	l0 uint64
+	l1 uint64
+	l2 uint64
+	l3 uint64
+}
+
+// Set sets v = a, and returns v.
+func (v *Element) Set(a *Element) *Element {
+	*v = *a
+	return v
+}
+
+// SetBytes sets v to x, where x is a 32-byte little-endian encoding. If x is
+// not of the right length, SetBytes returns nil and an error, and the
+// receiver is unchanged.
+//
+// Consistent with RFC 7748, the most significant bit (the high bit of the
+// last byte) is ignored, and non-canonical values (2^255-19 through 2^255-1)
+// are accepted. Note that this is laxer than specified by RFC 8032, but
+// consistent with most Ed25519 implementations.
+func (v *Element) SetBytes(x []byte) (*Element, error) {
+	if len(x) != 32 {
+		return nil, errors.New("edwards25519: invalid field element input size")
+	}
+
+	v.l0 = binary.LittleEndian.Uint64(x[0*8:])
+	v.l1 = binary.LittleEndian.Uint64(x[1*8:])
+	v.l2 = binary.LittleEndian.Uint64(x[2*8:])
+	v.l3 = binary.LittleEndian.Uint64(x[3*8:])
+	v.l3 &= (1<<63 - 1)
+
+	return v, nil
+}
+
+// Bytes returns the canonical 32-byte little-endian encoding of v.
+func (v *Element) Bytes() []byte {
+	// This function is outlined to make the allocations inline in the caller
+	// rather than happen on the heap.
+	var out [32]byte
+	return v.bytes(&out)
+}
+
+// FillBytes sets buf the canonical 32-byte little-endian encoding of v, and returns buf.
+// If the value of v doesn't fit in buf, FillBytes will panic.
+func (v *Element) FillBytes(buf []byte) []byte {
+	binary.LittleEndian.PutUint64(buf[0*8:], v.l0)
+	binary.LittleEndian.PutUint64(buf[1*8:], v.l1)
+	binary.LittleEndian.PutUint64(buf[2*8:], v.l2)
+	binary.LittleEndian.PutUint64(buf[3*8:], v.l3)
+
+	return buf
+}
+
+func (v *Element) bytes(out *[32]byte) []byte {
+	binary.LittleEndian.PutUint64(out[0*8:], v.l0)
+	binary.LittleEndian.PutUint64(out[1*8:], v.l1)
+	binary.LittleEndian.PutUint64(out[2*8:], v.l2)
+	binary.LittleEndian.PutUint64(out[3*8:], v.l3)
+
+	return out[:]
+}
+
+// Equal returns 1 if v and u are equal, and 0 otherwise.
+func (v *Element) Equal(u *Element) int {
+	su, sv := u.Bytes(), v.Bytes()
+	return subtle.ConstantTimeCompare(su, sv)
+}
+
+// mask64Bits returns 0xffffffff if cond is 1, and 0 otherwise.
+func mask64Bits(cond int) uint64 { return ^(uint64(cond) - 1) }
+
+// Select sets v to a if cond == 1, and to b if cond == 0.
+func (v *Element) Select(a, b *Element, cond int) *Element {
+	m := mask64Bits(cond)
+	v.l0 = (m & a.l0) | (^m & b.l0)
+	v.l1 = (m & a.l1) | (^m & b.l1)
+	v.l2 = (m & a.l2) | (^m & b.l2)
+	v.l3 = (m & a.l3) | (^m & b.l3)
+	return v
+}
+
+// Swap swaps v and u if cond == 1 or leaves them unchanged if cond == 0, and returns v.
+func (v *Element) Swap(u *Element, cond int) {
+	m := mask64Bits(cond)
+	t := m & (v.l0 ^ u.l0)
+	v.l0 ^= t
+	u.l0 ^= t
+	t = m & (v.l1 ^ u.l1)
+	v.l1 ^= t
+	u.l1 ^= t
+	t = m & (v.l2 ^ u.l2)
+	v.l2 ^= t
+	u.l2 ^= t
+	t = m & (v.l3 ^ u.l3)
+	v.l3 ^= t
+	u.l3 ^= t
+}
+
+var feZero = &Element{0, 0, 0, 0}
+
+// Zero sets v = 0, and returns v.
+func (v *Element) Zero() *Element {
+	*v = *feZero
+	return v
+}
+
+var feOne = &Element{1, 0, 0, 0}
+
+// One sets v = 1, and returns v.
+func (v *Element) One() *Element {
+	*v = *feOne
+	return v
+}
+
+// Add sets v = x + y, and returns v.
+func (v *Element) Add(x, y *Element) *Element {
+	bignum_add_p25519(v, x, y)
+	return v
+}
+
+// Subtract sets v = a - b, and returns v.
+func (v *Element) Subtract(a, b *Element) *Element {
+	bignum_sub_p25519(v, a, b)
+	return v
+}
+
+// Multiply sets v = x * y, and returns v.
+func (v *Element) Multiply(x, y *Element) *Element {
+	bignum_mul_p25519(v, x, y)
+	return v
+}
+
+// Square sets v = x * x, and returns v.
+func (v *Element) Square(x *Element) *Element {
+	bignum_sqr_p25519(v, x)
+	return v
+}
+
+// Negate sets v = -a, and returns v.
+func (v *Element) Negate(a *Element) *Element {
+	return v.Subtract(feZero, a)
+}
+
+// IsNegative returns 1 if v is negative, and 0 otherwise.
+func (v *Element) IsNegative() int {
+	return int(v.Bytes()[0] & 1)
+}
+
+// Absolute sets v to |u|, and returns v.
+func (v *Element) Absolute(u *Element) *Element {
+	return v.Select(new(Element).Negate(u), u, u.IsNegative())
+}
+
+// Invert sets v = 1/z mod p, and returns v.
+//
+// If z == 0, Invert returns v = 0.
+func (v *Element) Invert(z *Element) *Element {
+	// Inversion is implemented as exponentiation with exponent p − 2. It uses the
+	// same sequence of 254 squarings and 11 multiplications as [Curve25519].
+	var z2, z9, z11, z2_5_0, z2_10_0, z2_20_0, z2_50_0, z2_100_0, t Element
+
+	z2.Square(z)             // 2
+	t.Square(&z2)            // 4
+	t.Square(&t)             // 8
+	z9.Multiply(&t, z)       // 9
+	z11.Multiply(&z9, &z2)   // 11
+	t.Square(&z11)           // 22
+	z2_5_0.Multiply(&t, &z9) // 31 = 2^5 - 2^0
+
+	t.Square(&z2_5_0) // 2^6 - 2^1
+	for i := 0; i < 4; i++ {
+		t.Square(&t) // 2^10 - 2^5
+	}
+	z2_10_0.Multiply(&t, &z2_5_0) // 2^10 - 2^0
+
+	t.Square(&z2_10_0) // 2^11 - 2^1
+	for i := 0; i < 9; i++ {
+		t.Square(&t) // 2^20 - 2^10
+	}
+	z2_20_0.Multiply(&t, &z2_10_0) // 2^20 - 2^0
+
+	t.Square(&z2_20_0) // 2^21 - 2^1
+	for i := 0; i < 19; i++ {
+		t.Square(&t) // 2^40 - 2^20
+	}
+	t.Multiply(&t, &z2_20_0) // 2^40 - 2^0
+
+	t.Square(&t) // 2^41 - 2^1
+	for i := 0; i < 9; i++ {
+		t.Square(&t) // 2^50 - 2^10
+	}
+	z2_50_0.Multiply(&t, &z2_10_0) // 2^50 - 2^0
+
+	t.Square(&z2_50_0) // 2^51 - 2^1
+	for i := 0; i < 49; i++ {
+		t.Square(&t) // 2^100 - 2^50
+	}
+	z2_100_0.Multiply(&t, &z2_50_0) // 2^100 - 2^0
+
+	t.Square(&z2_100_0) // 2^101 - 2^1
+	for i := 0; i < 99; i++ {
+		t.Square(&t) // 2^200 - 2^100
+	}
+	t.Multiply(&t, &z2_100_0) // 2^200 - 2^0
+
+	t.Square(&t) // 2^201 - 2^1
+	for i := 0; i < 49; i++ {
+		t.Square(&t) // 2^250 - 2^50
+	}
+	t.Multiply(&t, &z2_50_0) // 2^250 - 2^0
+
+	t.Square(&t) // 2^251 - 2^1
+	t.Square(&t) // 2^252 - 2^2
+	t.Square(&t) // 2^253 - 2^3
+	t.Square(&t) // 2^254 - 2^4
+	t.Square(&t) // 2^255 - 2^5
+
+	return v.Multiply(&t, &z11) // 2^255 - 21
+}
+
+// Mult32 sets v = x * y, and returns v.
+func (v *Element) Mult32(x *Element, y uint32) *Element {
+	return v.Multiply(x, &Element{uint64(y), 0, 0, 0})
+}
+
+// Pow22523 set v = x^((p-5)/8), and returns v. (p-5)/8 is 2^252-3.
+func (v *Element) Pow22523(x *Element) *Element {
+	var t0, t1, t2 Element
+
+	t0.Square(x)             // x^2
+	t1.Square(&t0)           // x^4
+	t1.Square(&t1)           // x^8
+	t1.Multiply(x, &t1)      // x^9
+	t0.Multiply(&t0, &t1)    // x^11
+	t0.Square(&t0)           // x^22
+	t0.Multiply(&t1, &t0)    // x^31
+	t1.Square(&t0)           // x^62
+	for i := 1; i < 5; i++ { // x^992
+		t1.Square(&t1)
+	}
+	t0.Multiply(&t1, &t0)     // x^1023 -> 1023 = 2^10 - 1
+	t1.Square(&t0)            // 2^11 - 2
+	for i := 1; i < 10; i++ { // 2^20 - 2^10
+		t1.Square(&t1)
+	}
+	t1.Multiply(&t1, &t0)     // 2^20 - 1
+	t2.Square(&t1)            // 2^21 - 2
+	for i := 1; i < 20; i++ { // 2^40 - 2^20
+		t2.Square(&t2)
+	}
+	t1.Multiply(&t2, &t1)     // 2^40 - 1
+	t1.Square(&t1)            // 2^41 - 2
+	for i := 1; i < 10; i++ { // 2^50 - 2^10
+		t1.Square(&t1)
+	}
+	t0.Multiply(&t1, &t0)     // 2^50 - 1
+	t1.Square(&t0)            // 2^51 - 2
+	for i := 1; i < 50; i++ { // 2^100 - 2^50
+		t1.Square(&t1)
+	}
+	t1.Multiply(&t1, &t0)      // 2^100 - 1
+	t2.Square(&t1)             // 2^101 - 2
+	for i := 1; i < 100; i++ { // 2^200 - 2^100
+		t2.Square(&t2)
+	}
+	t1.Multiply(&t2, &t1)     // 2^200 - 1
+	t1.Square(&t1)            // 2^201 - 2
+	for i := 1; i < 50; i++ { // 2^250 - 2^50
+		t1.Square(&t1)
+	}
+	t0.Multiply(&t1, &t0)     // 2^250 - 1
+	t0.Square(&t0)            // 2^251 - 2
+	t0.Square(&t0)            // 2^252 - 4
+	return v.Multiply(&t0, x) // 2^252 - 3 -> x^(2^252-3)
+}
+
+// sqrtM1 is 2^((p-1)/4), which squared is equal to -1 by Euler's Criterion.
+var sqrtM1 = &Element{
+	l0: 14190309331451158704,
+	l1: 3405592160176694392,
+	l2: 3120150775007532967,
+	l3: 3135389899092516619,
+}
+
+// SqrtRatio sets r to the non-negative square root of the ratio of u and v.
+//
+// If u/v is square, SqrtRatio returns r and 1. If u/v is not square, SqrtRatio
+// sets r according to Section 4.3 of draft-irtf-cfrg-ristretto255-decaf448-00,
+// and returns r and 0.
+func (r *Element) SqrtRatio(u, v *Element) (R *Element, wasSquare int) {
+	t0 := new(Element)
+
+	// r = (u * v3) * (u * v7)^((p-5)/8)
+	v2 := new(Element).Square(v)
+	uv3 := new(Element).Multiply(u, t0.Multiply(v2, v))
+	uv7 := new(Element).Multiply(uv3, t0.Square(v2))
+	rr := new(Element).Multiply(uv3, t0.Pow22523(uv7))
+
+	check := new(Element).Multiply(v, t0.Square(rr)) // check = v * r^2
+
+	uNeg := new(Element).Negate(u)
+	correctSignSqrt := check.Equal(u)
+	flippedSignSqrt := check.Equal(uNeg)
+	flippedSignSqrtI := check.Equal(t0.Multiply(uNeg, sqrtM1))
+
+	rPrime := new(Element).Multiply(rr, sqrtM1) // r_prime = SQRT_M1 * r
+	// r = CT_SELECT(r_prime IF flipped_sign_sqrt | flipped_sign_sqrt_i ELSE r)
+	rr.Select(rPrime, rr, flippedSignSqrt|flippedSignSqrtI)
+
+	r.Absolute(rr) // Choose the nonnegative square root.
+	return r, correctSignSqrt | flippedSignSqrt
+}

--- a/field/fe_amd64.go
+++ b/field/fe_amd64.go
@@ -1,0 +1,23 @@
+//go:build amd64 && gc && !purego
+
+package field
+
+// bignum_add_p25519 sets out = a + b.
+//
+//go:noescape
+func bignum_add_p25519(out *Element, a *Element, b *Element)
+
+// bignum_sub_p25519 sets out = a - b.
+//
+//go:noescape
+func bignum_sub_p25519(out *Element, a *Element, b *Element)
+
+// bignum_mul_p25519 sets out = a * b.
+//
+//go:noescape
+func bignum_mul_p25519(out *Element, a *Element, b *Element)
+
+// bignum_sqr_p25519 sets out = a * a.
+//
+//go:noescape
+func bignum_sqr_p25519(out *Element, a *Element)

--- a/field/fe_arm64.go
+++ b/field/fe_arm64.go
@@ -1,0 +1,23 @@
+//go:build arm64 && gc && !purego
+
+package field
+
+// bignum_add_p25519 sets out = a + b.
+//
+//go:noescape
+func bignum_add_p25519(out *Element, a *Element, b *Element)
+
+// bignum_sub_p25519 sets out = a - b.
+//
+//go:noescape
+func bignum_sub_p25519(out *Element, a *Element, b *Element)
+
+// bignum_mul_p25519 sets out = a * b.
+//
+//go:noescape
+func bignum_mul_p25519(out *Element, a *Element, b *Element)
+
+// bignum_sqr_p25519 sets out = a * a.
+//
+//go:noescape
+func bignum_sqr_p25519(out *Element, a *Element)

--- a/field/fe_test.go
+++ b/field/fe_test.go
@@ -1,0 +1,248 @@
+package field
+
+import (
+	"encoding/hex"
+	"math/bits"
+	mathrand "math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/AlexanderYastrebov/vanity25519/internal/assert"
+)
+
+// quickCheckConfig returns a quick.Config that scales the max count by the
+// given factor if the -short flag is not set.
+func quickCheckConfig(slowScale int) *quick.Config {
+	cfg := new(quick.Config)
+	if !testing.Short() {
+		cfg.MaxCountScale = float64(slowScale)
+	}
+	return cfg
+}
+
+func generateFieldElement(rand *mathrand.Rand) Element {
+	const maskLow63Bits = (1 << 63) - 1
+	return Element{
+		rand.Uint64(),
+		rand.Uint64(),
+		rand.Uint64(),
+		rand.Uint64() & maskLow63Bits,
+	}
+}
+
+func (Element) Generate(rand *mathrand.Rand, size int) reflect.Value {
+	return reflect.ValueOf(generateFieldElement(rand))
+}
+
+// isInBounds returns whether the element is within the expected bit size bounds.
+func isInBounds(x *Element) bool {
+	return bits.Len64(x.l0) <= 64 &&
+		bits.Len64(x.l1) <= 64 &&
+		bits.Len64(x.l2) <= 64 &&
+		bits.Len64(x.l3) <= 63
+}
+
+func TestAdd(t *testing.T) {
+	x := new(Element).One()
+	y := new(Element).Add(x, x)
+
+	for range 10 {
+		x.Add(x, y)
+	}
+
+	assert.Equal(t, uint64(21), x.l0)
+	assert.Equal(t, uint64(0), x.l1)
+	assert.Equal(t, uint64(0), x.l2)
+	assert.Equal(t, uint64(0), x.l3)
+}
+
+func TestSubtract(t *testing.T) {
+	x := new(Element).One()
+	y := new(Element).Add(x, x)
+
+	for range 10 {
+		x.Subtract(x, y)
+	}
+
+	assert.Equal(t, uint64(1<<64-19-19), x.l0)
+	assert.Equal(t, uint64(1<<64-1), x.l1)
+	assert.Equal(t, uint64(1<<64-1), x.l2)
+	assert.Equal(t, uint64(1<<63-1), x.l3)
+}
+
+func TestMultiply(t *testing.T) {
+	x := new(Element).One()
+	y := new(Element).Add(x, x)
+
+	for range 10 {
+		x.Multiply(x, y)
+	}
+
+	assert.Equal(t, uint64(1024), x.l0)
+	assert.Equal(t, uint64(0), x.l1)
+	assert.Equal(t, uint64(0), x.l2)
+	assert.Equal(t, uint64(0), x.l3)
+}
+
+func TestSquare(t *testing.T) {
+	x := new(Element).Add(feOne, feOne)
+
+	for range 3 {
+		x.Square(x)
+	}
+
+	assert.Equal(t, uint64(256), x.l0)
+	assert.Equal(t, uint64(0), x.l1)
+	assert.Equal(t, uint64(0), x.l2)
+	assert.Equal(t, uint64(0), x.l3)
+}
+
+func TestMultiplyDistributesOverAdd(t *testing.T) {
+	multiplyDistributesOverAdd := func(x, y, z Element) bool {
+		// Compute t1 = (x+y)*z
+		t1 := new(Element)
+		t1.Add(&x, &y)
+		t1.Multiply(t1, &z)
+
+		// Compute t2 = x*z + y*z
+		t2 := new(Element)
+		t3 := new(Element)
+		t2.Multiply(&x, &z)
+		t3.Multiply(&y, &z)
+		t2.Add(t2, t3)
+
+		return t1.Equal(t2) == 1 && isInBounds(t1) && isInBounds(t2)
+	}
+
+	err := quick.Check(multiplyDistributesOverAdd, quickCheckConfig(1024))
+	assert.NoError(t, err)
+}
+
+func TestSqrtRatio(t *testing.T) {
+	// From draft-irtf-cfrg-ristretto255-decaf448-00, Appendix A.4.
+	type test struct {
+		u, v      string
+		wasSquare int
+		r         string
+	}
+	tests := []test{
+		// If u is 0, the function is defined to return (0, TRUE), even if v
+		// is zero. Note that where used in this package, the denominator v
+		// is never zero.
+		{
+			"0000000000000000000000000000000000000000000000000000000000000000",
+			"0000000000000000000000000000000000000000000000000000000000000000",
+			1, "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		// 0/1 == 0²
+		{
+			"0000000000000000000000000000000000000000000000000000000000000000",
+			"0100000000000000000000000000000000000000000000000000000000000000",
+			1, "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		// If u is non-zero and v is zero, defined to return (0, FALSE).
+		{
+			"0100000000000000000000000000000000000000000000000000000000000000",
+			"0000000000000000000000000000000000000000000000000000000000000000",
+			0, "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		// 2/1 is not square in this field.
+		{
+			"0200000000000000000000000000000000000000000000000000000000000000",
+			"0100000000000000000000000000000000000000000000000000000000000000",
+			0, "3c5ff1b5d8e4113b871bd052f9e7bcd0582804c266ffb2d4f4203eb07fdb7c54",
+		},
+		// 4/1 == 2²
+		{
+			"0400000000000000000000000000000000000000000000000000000000000000",
+			"0100000000000000000000000000000000000000000000000000000000000000",
+			1, "0200000000000000000000000000000000000000000000000000000000000000",
+		},
+		// 1/4 == (2⁻¹)² == (2^(p-2))² per Euler's theorem
+		{
+			"0100000000000000000000000000000000000000000000000000000000000000",
+			"0400000000000000000000000000000000000000000000000000000000000000",
+			1, "f6ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+		},
+	}
+
+	for i, tt := range tests {
+		u, _ := new(Element).SetBytes(decodeHex(tt.u))
+		v, _ := new(Element).SetBytes(decodeHex(tt.v))
+		want, _ := new(Element).SetBytes(decodeHex(tt.r))
+		got, wasSquare := new(Element).SqrtRatio(u, v)
+		if got.Equal(want) == 0 || wasSquare != tt.wasSquare {
+			t.Errorf("%d: got (%v, %v), want (%v, %v)", i, got, wasSquare, want, tt.wasSquare)
+		}
+	}
+}
+
+func decodeHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func BenchmarkAdd(b *testing.B) {
+	x := new(Element).One()
+	y := new(Element).Add(x, x)
+
+	b.ResetTimer()
+	for range b.N {
+		x.Add(x, y)
+	}
+}
+
+func BenchmarkSubtract(b *testing.B) {
+	x := new(Element).One()
+	y := new(Element).Add(x, x)
+
+	b.ResetTimer()
+	for range b.N {
+		x.Subtract(x, y)
+	}
+}
+
+func BenchmarkMultiply(b *testing.B) {
+	x := new(Element).One()
+	y := new(Element).Add(x, x)
+
+	b.ResetTimer()
+	for range b.N {
+		x.Multiply(x, y)
+	}
+}
+
+var z Element
+
+func BenchmarkMultiplyNoAlias(b *testing.B) {
+	x := new(Element).One()
+	y := new(Element).Add(x, x)
+
+	b.ResetTimer()
+	for range b.N {
+		z.Multiply(x, y)
+	}
+}
+
+func BenchmarkMultiplyParallel(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		x := new(Element).One()
+		y := new(Element).Add(x, x)
+		for pb.Next() {
+			x.Multiply(x, y)
+		}
+	})
+}
+
+func BenchmarkSquare(b *testing.B) {
+	x := new(Element).Add(feOne, feOne)
+
+	b.ResetTimer()
+	for range b.N {
+		x.Square(x)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/AlexanderYastrebov/vanity25519
 
-go 1.24.0
+go 1.25.0
 
 require filippo.io/edwards25519 v1.1.1-0.20250211130249-04b037b40df0

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,38 @@
+package assert
+
+import (
+	"reflect"
+	"testing"
+)
+
+// True asserts that the value is true
+func True(t *testing.T, value bool) {
+	if !value {
+		t.Helper()
+		t.Error("Should be true")
+	}
+}
+
+// False asserts that the value is false
+func False(t *testing.T, value bool) {
+	if value {
+		t.Helper()
+		t.Error("Should be false")
+	}
+}
+
+// Equal asserts that expected and actual are equal using reflect.DeepEqual
+func Equal(t *testing.T, expected, actual any) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Helper()
+		t.Errorf("Not equal:\nexpected: %v\n  actual: %v", expected, actual)
+	}
+}
+
+// NoError asserts that the error is nil
+func NoError(t *testing.T, err error) {
+	if err != nil {
+		t.Helper()
+		t.Errorf("Received unexpected error: %+v", err)
+	}
+}

--- a/internal/require/require.go
+++ b/internal/require/require.go
@@ -1,0 +1,38 @@
+package require
+
+import (
+	"reflect"
+	"testing"
+)
+
+// True requires that the value is true, failing the test if not
+func True(t *testing.T, value bool) {
+	if !value {
+		t.Helper()
+		t.Fatal("Should be true")
+	}
+}
+
+// False requires that the value is false, failing the test if not
+func False(t *testing.T, value bool) {
+	if value {
+		t.Helper()
+		t.Fatal("Should be false")
+	}
+}
+
+// Equal requires that expected and actual are equal using reflect.DeepEqual
+func Equal(t *testing.T, expected, actual any) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Helper()
+		t.Fatalf("Not equal:\nexpected: %v\n  actual: %v", expected, actual)
+	}
+}
+
+// NoError requires that the error is nil, failing the test if not
+func NoError(t *testing.T, err error) {
+	if err != nil {
+		t.Helper()
+		t.Fatalf("Received unexpected error: %+v", err)
+	}
+}

--- a/montgomery_test.go
+++ b/montgomery_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	"filippo.io/edwards25519"
-	"filippo.io/edwards25519/field"
+	"github.com/AlexanderYastrebov/vanity25519/field"
+	"github.com/AlexanderYastrebov/vanity25519/internal/assert"
 )
 
 var (
@@ -29,8 +30,8 @@ func TestMontgomeryFromEdwards(t *testing.T) {
 	b := montgomeryFromEdwards(g)
 	t.Log(b)
 
-	assertEqual(t, _B.x.Bytes(), b.x.Bytes())
-	assertEqual(t, _B.y.Bytes(), b.y.Bytes())
+	assert.Equal(t, _B.x.Bytes(), b.x.Bytes())
+	assert.Equal(t, _B.y.Bytes(), b.y.Bytes())
 }
 
 func TestEdwardsFromMontgomery(t *testing.T) {
@@ -39,7 +40,7 @@ func TestEdwardsFromMontgomery(t *testing.T) {
 	b := edwardsFromMontgomery(_B)
 	t.Log(b)
 
-	assertEqual(t, 1, g.Equal(b))
+	assert.Equal(t, 1, g.Equal(b))
 }
 
 func TestAddX(t *testing.T) {
@@ -53,7 +54,7 @@ func TestAddX(t *testing.T) {
 	addX(&x3, montgomery3, montgomery5)
 	t.Logf("Calculated x3: %x", x3.Bytes())
 
-	assertEqual(t, expectedU, x3.Bytes())
+	assert.Equal(t, expectedU, x3.Bytes())
 }
 
 func TestAddY(t *testing.T) {
@@ -67,7 +68,7 @@ func TestAddY(t *testing.T) {
 	addY(&y3, montgomery3, montgomery5)
 	t.Logf("Calculated y3: %x", y3.Bytes())
 
-	assertEqual(t, expectedV.Bytes(), y3.Bytes())
+	assert.Equal(t, expectedV.Bytes(), y3.Bytes())
 }
 
 func TestAdd(t *testing.T) {
@@ -79,8 +80,8 @@ func TestAdd(t *testing.T) {
 
 	t.Log(got)
 
-	assertEqual(t, expectedMontgomery8.x.Bytes(), got.x.Bytes())
-	assertEqual(t, expectedMontgomery8.y.Bytes(), got.y.Bytes())
+	assert.Equal(t, expectedMontgomery8.x.Bytes(), got.x.Bytes())
+	assert.Equal(t, expectedMontgomery8.y.Bytes(), got.y.Bytes())
 }
 
 func TestAddAlias(t *testing.T) {
@@ -93,8 +94,8 @@ func TestAddAlias(t *testing.T) {
 
 	t.Log(got)
 
-	assertEqual(t, expectedMontgomery8.x.Bytes(), got.x.Bytes())
-	assertEqual(t, expectedMontgomery8.y.Bytes(), got.y.Bytes())
+	assert.Equal(t, expectedMontgomery8.x.Bytes(), got.x.Bytes())
+	assert.Equal(t, expectedMontgomery8.y.Bytes(), got.y.Bytes())
 }
 
 func TestSub(t *testing.T) {
@@ -107,8 +108,8 @@ func TestSub(t *testing.T) {
 
 	t.Log(got)
 
-	assertEqual(t, expectedMontgomery2.x.Bytes(), got.x.Bytes())
-	assertEqual(t, expectedMontgomery2.y.Bytes(), got.y.Bytes())
+	assert.Equal(t, expectedMontgomery2.x.Bytes(), got.x.Bytes())
+	assert.Equal(t, expectedMontgomery2.y.Bytes(), got.y.Bytes())
 }
 
 func TestDouble(t *testing.T) {
@@ -122,8 +123,8 @@ func TestDouble(t *testing.T) {
 	t.Logf("Expected Montgomery 6: %s", expectedMontgomery6)
 	t.Logf("Calculated Montgomery 6: %s", montgomery6)
 
-	assertEqual(t, expectedMontgomery6.x.Bytes(), montgomery6.x.Bytes())
-	assertEqual(t, expectedMontgomery6.y.Bytes(), montgomery6.y.Bytes())
+	assert.Equal(t, expectedMontgomery6.x.Bytes(), montgomery6.x.Bytes())
+	assert.Equal(t, expectedMontgomery6.y.Bytes(), montgomery6.y.Bytes())
 }
 
 func TestDoubleAlias(t *testing.T) {
@@ -132,8 +133,8 @@ func TestDoubleAlias(t *testing.T) {
 	montgomery2 := new(point).set(_B)
 	montgomery2.double(montgomery2)
 
-	assertEqual(t, expectedMontgomery2.x.Bytes(), montgomery2.x.Bytes())
-	assertEqual(t, expectedMontgomery2.y.Bytes(), montgomery2.y.Bytes())
+	assert.Equal(t, expectedMontgomery2.x.Bytes(), montgomery2.x.Bytes())
+	assert.Equal(t, expectedMontgomery2.y.Bytes(), montgomery2.y.Bytes())
 }
 
 func TestB8(t *testing.T) {
@@ -144,8 +145,8 @@ func TestB8(t *testing.T) {
 	t.Logf("Expected Montgomery B8: %s", expectedMontgomeryB8)
 	t.Logf("Calculated Montgomery B8: %s", _B8)
 
-	assertEqual(t, expectedMontgomeryB8.x.Bytes(), _B8.x.Bytes())
-	assertEqual(t, expectedMontgomeryB8.y.Bytes(), _B8.y.Bytes())
+	assert.Equal(t, expectedMontgomeryB8.x.Bytes(), _B8.x.Bytes())
+	assert.Equal(t, expectedMontgomeryB8.y.Bytes(), _B8.y.Bytes())
 }
 
 func TestSetBytes(t *testing.T) {
@@ -155,7 +156,7 @@ func TestSetBytes(t *testing.T) {
 	}
 
 	p, err := new(point).setBytes(_B.x.Bytes())
-	assertNoError(t, err)
-	assertEqual(t, _B.x.Bytes(), p.x.Bytes())
-	assertEqual(t, expectedY.Bytes(), p.y.Bytes())
+	assert.NoError(t, err)
+	assert.Equal(t, _B.x.Bytes(), p.x.Bytes())
+	assert.Equal(t, expectedY.Bytes(), p.y.Bytes())
 }

--- a/search.go
+++ b/search.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 
 	"filippo.io/edwards25519"
-	"filippo.io/edwards25519/field"
+	"github.com/AlexanderYastrebov/vanity25519/field"
 )
 
 // Search generates candidate curve25519 public keys by adding batches of incrementing offsets to the start public key.
@@ -77,8 +77,7 @@ func Search(ctx context.Context, startPublicKey []byte, startOffset *big.Int, ba
 		addXBatch(p, offsets, dx, x)
 
 		for j := range x {
-			copy(bm[:], x[j].Bytes()) // eliminate field.Element.Bytes() allocations
-			if accept(bm[:]) {
+			if accept(x[j].FillBytes(bm[:])) {
 				offset := new(big.Int).Add(startOffset, new(big.Int).SetUint64(i))
 				if j < batchSize/2 {
 					offset.Add(offset, big.NewInt(int64(j+1)))
@@ -89,8 +88,7 @@ func Search(ctx context.Context, startPublicKey []byte, startOffset *big.Int, ba
 			}
 		}
 
-		copy(bm[:], p.x.Bytes())
-		if accept(bm[:]) {
+		if accept(p.x.FillBytes(bm[:])) {
 			offset := new(big.Int).Add(startOffset, new(big.Int).SetUint64(i))
 			yield(slices.Clone(bm[:]), offset)
 		}

--- a/search_test.go
+++ b/search_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 
 	"filippo.io/edwards25519"
-	"filippo.io/edwards25519/field"
+	"github.com/AlexanderYastrebov/vanity25519/field"
+	"github.com/AlexanderYastrebov/vanity25519/internal/assert"
+	"github.com/AlexanderYastrebov/vanity25519/internal/require"
 )
 
 func TestMakeOffsets(t *testing.T) {
@@ -22,8 +24,8 @@ func TestMakeOffsets(t *testing.T) {
 		expectedEdwards := edwards25519.NewGeneratorPoint().ScalarBaseMult(scalarFromUint64(uint64(i+1) * 8))
 		expectedMontgomery := montgomeryFromEdwards(expectedEdwards)
 
-		assertEqual(t, expectedMontgomery.x.Bytes(), offsets[i].x.Bytes())
-		assertEqual(t, expectedMontgomery.y.Bytes(), offsets[i].y.Bytes())
+		assert.Equal(t, expectedMontgomery.x.Bytes(), offsets[i].x.Bytes())
+		assert.Equal(t, expectedMontgomery.y.Bytes(), offsets[i].y.Bytes())
 	}
 }
 
@@ -45,7 +47,7 @@ func TestInvert(t *testing.T) {
 			invert(a, s)
 
 			for i := range n {
-				assertEqual(t, e[i].Bytes(), a[i].Bytes())
+				assert.Equal(t, e[i].Bytes(), a[i].Bytes())
 			}
 		})
 	}
@@ -78,9 +80,9 @@ func TestAddXBatch(t *testing.T) {
 	addXBatch(p1, makeOffsets(n), dx, x)
 
 	for i := range x {
-		assertEqual(t, expectedX[i].Bytes(), x[i].Bytes())
+		assert.Equal(t, expectedX[i].Bytes(), x[i].Bytes())
 	}
-	assertEqual(t, dxInvExpectedBytes, dx[n].Bytes())
+	assert.Equal(t, dxInvExpectedBytes, dx[n].Bytes())
 }
 
 func TestSearch(t *testing.T) {
@@ -88,7 +90,7 @@ func TestSearch(t *testing.T) {
 		const k = "qkHBetbXfAxsmr0jH6Zs6Dx1ZEReO9WBZCoNREce0gE="
 
 		kb, err := base64.StdEncoding.DecodeString(k)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		expectedOffset := big.NewInt(92950)
 
@@ -105,16 +107,16 @@ func TestSearch(t *testing.T) {
 
 		Search(ctx, kb, big.NewInt(0), 8, accept, yield)
 
-		assertEqual(t, expectedOffset, found)
+		assert.Equal(t, expectedOffset, found)
 
 		p, err := edwardsPointFromMontgomeryBytes(kb)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		po := new(edwards25519.Point).ScalarBaseMult(scalarFromBigInt(found))
 		po.MultByCofactor(po)
 		p.Add(p, po)
 
-		assertEqual(t, "AY/yq7zukqRmMUzqqPFmtqXJdAcbmh8mn4rMgtjVnGI=", base64.StdEncoding.EncodeToString(p.BytesMontgomery()))
+		assert.Equal(t, "AY/yq7zukqRmMUzqqPFmtqXJdAcbmh8mn4rMgtjVnGI=", base64.StdEncoding.EncodeToString(p.BytesMontgomery()))
 	})
 
 	acceptAll := func(_ []byte) bool { return true }
@@ -125,14 +127,14 @@ func TestSearch(t *testing.T) {
 		const pk = "2U15Ir9CYFkGDAOtgsqWagSa+RKdXCHqjKm0kPkwm20="
 
 		skb, err := base64.StdEncoding.DecodeString(sk)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		pkb, err := base64.StdEncoding.DecodeString(pk)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		k, err := ecdh.X25519().NewPrivateKey(skb)
-		requireNoError(t, err)
-		assertEqual(t, k.PublicKey().Bytes(), pkb)
+		require.NoError(t, err)
+		assert.Equal(t, k.PublicKey().Bytes(), pkb)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -140,11 +142,11 @@ func TestSearch(t *testing.T) {
 		i := 0
 		Search(ctx, pkb, big.NewInt(0), 8, acceptAll, func(xb []byte, offset *big.Int) {
 			kb, err := Add(skb, offset)
-			requireNoError(t, err)
+			require.NoError(t, err)
 
 			k, err := ecdh.X25519().NewPrivateKey(kb)
-			assertNoError(t, err)
-			assertEqual(t, k.PublicKey().Bytes(), xb)
+			assert.NoError(t, err)
+			assert.Equal(t, k.PublicKey().Bytes(), xb)
 
 			if i++; i == n {
 				cancel()
@@ -156,7 +158,7 @@ func TestSearch(t *testing.T) {
 		for range 100 {
 			t.Run("", func(t *testing.T) {
 				k, err := ecdh.X25519().GenerateKey(rand.Reader)
-				requireNoError(t, err)
+				require.NoError(t, err)
 				skb := k.Bytes()
 				pkb := k.PublicKey().Bytes()
 
@@ -169,11 +171,11 @@ func TestSearch(t *testing.T) {
 				i := 0
 				Search(ctx, pkb, startOffset, 8, acceptAll, func(xb []byte, offset *big.Int) {
 					kb, err := Add(skb, offset)
-					requireNoError(t, err)
+					require.NoError(t, err)
 
 					k, err = ecdh.X25519().NewPrivateKey(kb)
-					assertNoError(t, err)
-					assertEqual(t, k.PublicKey().Bytes(), xb)
+					assert.NoError(t, err)
+					assert.Equal(t, k.PublicKey().Bytes(), xb)
 
 					if i++; i == 100 {
 						cancel()
@@ -201,7 +203,7 @@ func BenchmarkSearch(b *testing.B) {
 					cancel()
 				}
 				return false
-			}, func([]byte, *big.Int) {})
+			}, nil)
 		})
 	}
 }

--- a/util.go
+++ b/util.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 
 	"filippo.io/edwards25519"
-	"filippo.io/edwards25519/field"
+	"github.com/AlexanderYastrebov/vanity25519/field"
 )
 
 // HasPrefixBits returns a function that checks if the input has the specified prefix bits.

--- a/util_test.go
+++ b/util_test.go
@@ -5,33 +5,34 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
-	"reflect"
 	"strings"
 	"testing"
 
 	"filippo.io/edwards25519"
+
+	"github.com/AlexanderYastrebov/vanity25519/internal/assert"
 )
 
 func TestHasPrefixBits(t *testing.T) {
 	t.Logf("AY/: % x", "AY/") // 41 59 2f
 
-	assertTrue(t, HasPrefixBits([]byte("AY/"), 8)([]byte{0x41, 0x59, 0x2f}))
-	assertTrue(t, HasPrefixBits([]byte("AY/"), 7)([]byte{0x40, 0x59, 0x2f}))
+	assert.True(t, HasPrefixBits([]byte("AY/"), 8)([]byte{0x41, 0x59, 0x2f}))
+	assert.True(t, HasPrefixBits([]byte("AY/"), 7)([]byte{0x40, 0x59, 0x2f}))
 
 	buf := make([]byte, 32)
 	rand.Read(buf)
 	input := bytes.Clone(buf)
 
 	for i := 1; i < 256; i++ {
-		assertTrue(t, HasPrefixBits(buf, i)(input))
+		assert.True(t, HasPrefixBits(buf, i)(input))
 	}
 
 	input[0] ^= 0x01
 	for i := 1; i < 8; i++ {
-		assertTrue(t, HasPrefixBits(buf, i)(input))
+		assert.True(t, HasPrefixBits(buf, i)(input))
 	}
 	for i := 8; i < 256; i++ {
-		assertFalse(t, HasPrefixBits(buf, i)(input))
+		assert.False(t, HasPrefixBits(buf, i)(input))
 	}
 }
 
@@ -66,39 +67,4 @@ func scalarFromUint64(n uint64) *edwards25519.Scalar {
 		panic(err)
 	}
 	return xs
-}
-
-func assertTrue(t *testing.T, value bool) {
-	if !value {
-		t.Helper()
-		t.Error("Should be true")
-	}
-}
-
-func assertFalse(t *testing.T, value bool) {
-	if value {
-		t.Helper()
-		t.Error("Should be false")
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	if !reflect.DeepEqual(expected, actual) {
-		t.Helper()
-		t.Errorf("Not equal:\nexpected: %v\n  actual: %v", expected, actual)
-	}
-}
-
-func assertNoError(t *testing.T, err error) {
-	if err != nil {
-		t.Helper()
-		t.Errorf("Received unexpected error: %+v", err)
-	}
-}
-
-func requireNoError(t *testing.T, err error) {
-	if err != nil {
-		t.Helper()
-		t.Fatalf("Received unexpected error: %+v", err)
-	}
 }


### PR DESCRIPTION
Implement field arithmetic by translating https://github.com/awslabs/s2n-bignum
field operations into go assembly.

```
goos: linux
goarch: amd64
pkg: github.com/AlexanderYastrebov/vanity25519
              │     main     │                HEAD                 │
              │    sec/op    │   sec/op     vs base                │
Search/4096-8   106.95n ± 1%   79.19n ± 0%  -25.96% (p=0.000 n=10)
```
```
goos: linux
goarch: amd64
pkg: github.com/AlexanderYastrebov/vanity25519
                      │   HEAD~1    │                HEAD                 │
                      │   sec/op    │   sec/op     vs base                │
SearchParallel/4096-8   25.40n ± 6%   18.21n ± 2%  -28.31% (p=0.000 n=10)

                      │   HEAD~1    │                HEAD                 │
                      │   keys/s    │   keys/s     vs base                │
SearchParallel/4096-8   39.38M ± 7%   54.92M ± 2%  +39.48% (p=0.000 n=10)
```